### PR TITLE
fix for starting services with a "run" method

### DIFF
--- a/bootstrap-node.js
+++ b/bootstrap-node.js
@@ -18,7 +18,7 @@ var fs = global['fs'] ? global['fs'] : require('fs');
 
 appController = undefined;
 
-function loadAndStart(paramsToScript, appId) {
+async function loadAndStart(paramsToScript, appId) {
 	var service_dir = paramsToScript[1];
 
 	var palmbus = global['palmbus'] ? global['palmbus'] : require('palmbus');
@@ -33,7 +33,7 @@ function loadAndStart(paramsToScript, appId) {
 	if (process.getuid() === 0) {
 		var dir = paramsToScript[0];
 		try {
-			var publicRolePath  = dir + '/roles/pub/' + appId + '.json';
+			var publicRolePath = dir + '/roles/pub/' + appId + '.json';
 			var privateRolePath = dir + '/roles/prv/' + appId + '.json';
 
 			var publicHandle = null;
@@ -61,10 +61,25 @@ function loadAndStart(paramsToScript, appId) {
 	}
 
 	if (fs.existsSync('package.json')) { // webos-service based Node module
-		//console.log('loading node module from ' + service_dir);
-		var mod = require(service_dir);
-		if (mod.run) {
-			mod.run(appId);
+		if (fs.existsSync(path.join(service_dir, 'node_modules'))) {
+			// TODO: ideally, we would enumerate everything in /usr/lib/node_modules and symlink it, but really this should be done at package install time
+			try {
+				await fs.promises.symlink('/usr/lib/node_modules/webos-service', path.join(service_dir, 'node_modules/webos-service'));
+			} catch (err) {
+				// ignore, probably symlinked already, or service author included it.
+			}
+		} else {
+			try {
+				await fs.promises.symlink('/usr/lib/node_modules', path.join(service_dir, 'node_modules'));
+			} catch {
+				// ignore, probably symlinked already
+			}
+		}
+
+		const importPath = require.resolve(service_dir);
+		const serviceModule = await import(importPath);
+		if (serviceModule && serviceModule.run && typeof serviceModule.run === 'function') {
+			serviceModule.run(appId);
 		}
 	} else {
 		console.error("Couldn't determine launch file for service path " + service_dir);

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -16,29 +16,29 @@
 MojoLoader = global['mojoloader'] ? global['mojoloader'] : require('mojoloader');
 var fs = global['fs'] ? global['fs'] : require('fs');
 
-IMPORTS = {require: require};
+IMPORTS = { require: require };
 
 // Patch to convert legacy http calls to new ones
 var version = process.version.split('.');
 var majorVersion = version[0].substring(1);
 var minorVersion = version[1];
 if ((majorVersion == 0 && minorVersion >= 4) || majorVersion > 0) {
-	(function() {
+	(function () {
 		var http = require('http');
 		var https = require('https');
 		var EventEmitter = require('events').EventEmitter;
-		http.createClient = function(port, host, secure) {
+		http.createClient = function (port, host, secure) {
 			var module = secure ? https : http;
 			var client = new EventEmitter();
 			var options = {
 				port: port,
 				host: host
 			};
-			client.request = function(method, path, headers) {
+			client.request = function (method, path, headers) {
 				options.method = method;
 				options.path = path;
 				options.headers = headers;
-				var request = module.request(options, function(response) {});
+				var request = module.request(options, function (response) { });
 				return request;
 			};
 			return client;
@@ -97,7 +97,7 @@ function parseParams(params) {
 		args[0] = appId + '.js';
 
 		process.setArgs(args);
-		process.setName({shortname: shortname});
+		process.setName({ shortname: shortname });
 	} else {
 		// Node.js 0.10
 		if (!global.unified_service) {
@@ -126,10 +126,10 @@ function getConsoleName(fullName) {
 	return cname;
 }
 
-exports.parse = function(loadAndStart, params) {
+exports.parse = async function (loadAndStart, params) {
 	var conf = parseParams(params || process.argv);
 
-	loadAndStart(conf.params, conf.appId);
+	await loadAndStart(conf.params, conf.appId);
 }
 
 exports.loadFile = loadFile;


### PR DESCRIPTION
Previously having a "run" method in a service that is not run via the
unified server would generate a runtime error that "name" does not exist.

This fixes it, so you can use services that are intended to start via
"run()", for nice things like setting up dependency injection